### PR TITLE
Follow debian package convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CONTROL_FILE:=$(DEBIAN_DIR)/control
 build_control_file:
 	mkdir -p $(DEBIAN_DIR)
 	VERSION=$(VERSION) \
+	CODENAME=$(CODENAME) \
 	ARCH=$(ARCH) \
 	envsubst < $(ROOT_DIR)/template/control > $(CONTROL_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION=2022.3.0
-CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | awk -F= '{ print $NF }')
-ARCH=$(dpkg --print-architecture)
+CODENAME=jammy
+ARCH=amd64
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 WORKSPACE_DIR:=$(ROOT_DIR)/workspace

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-ARCH=amd64
 VERSION=2022.3.0
+CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | awk -F= '{ print $NF }')
+ARCH=$(dpkg --print-architecture)
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 WORKSPACE_DIR:=$(ROOT_DIR)/workspace
@@ -12,7 +13,7 @@ OUTPUT_DIR:=$(ROOT_DIR)/output
 build: build_control_file build_openvino
 	mkdir -p $(OUTPUT_DIR)
 	dpkg-deb --build --root-owner-group $(DPKG_ROOT) \
-		$(OUTPUT_DIR)/openvino-$(ARCH)-$(VERSION).deb
+		$(OUTPUT_DIR)/openvino_$(VERSION)-0$(CODENAME)_$(ARCH).deb
 
 build_container:
 	docker build -t openvino_builder $(ROOT_DIR)/docker

--- a/template/control
+++ b/template/control
@@ -1,6 +1,6 @@
 Package: openvino
-Version: $VERSION
-Section: base
+Version: $VERSION-0$CODENAME
+Section: devel
 Priority: optional
 Architecture: $ARCH
 Depends: git,cmake,libusb-1.0-0-dev,libpugixml-dev

--- a/workspace/build.bash
+++ b/workspace/build.bash
@@ -20,7 +20,6 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DTHREADING=SEQ \
   -DENABLE_PYTHON=OFF \
-  -DCMAKE_INSTALL_PREFIX=/opt/intel/openvino \
   -DCMAKE_CXX_FLAGS="-march=native -mtune=native -O3" \
   -DCMAKE_C_FLAGS="-march=native -mtune=native -O3" ..
 


### PR DESCRIPTION
There are some conventions for .deb filename and control file

- the filename should be `<foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb`
  - `<DebianRevisionNumber>` consists of revision number and distribution codename. Revision number needs to be incremented when the source code is not changed but the debian package is updated (e.g. control files are updated). But I guess such case would not happen in this package, so I've set this value as fixe value `0`.
- "section" of the control file doesn't need to follow the convention of Debian archive sites. But it tends to be `devel` or `misc` (miscellaneous) for this type of package.. Our custom ROS2 package's section is `misc`.

Reference: [Basics of the Debian package management system](https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html)