### PR TITLE
Use CPack Generator instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 deb
-output

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ build_openvino: build_container
 
 output_deb: build_openvino
 	mkdir -p $(ROOT_DIR)/deb/
-	cp $(WORKSPACE_DIR)/build/*.deb $(ROOT_DIR)/deb/
+	find $(WORKSPACE_DIR)/ -type f -name "*.deb" -exec cp {} $(ROOT_DIR)/deb/ \;

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,20 @@
-ARCH=amd64
-VERSION=2022.3.0
+.DEFAULT_GOAL := build
 
+OPENVINO_VERSION=2022.3.0
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 WORKSPACE_DIR:=$(ROOT_DIR)/workspace
 
-DPKG_ROOT:=$(ROOT_DIR)/deb/openvino
-OPENVINO_ROOT:=/opt/intel/openvino
-INSTALL_DIR:=$(DPKG_ROOT)/$(OPENVINO_ROOT)
-
-OUTPUT_DIR:=$(ROOT_DIR)/output
-build: build_control_file build_openvino
-	mkdir -p $(OUTPUT_DIR)
-	dpkg-deb --build --root-owner-group $(DPKG_ROOT) \
-		$(OUTPUT_DIR)/openvino-$(ARCH)-$(VERSION).deb
+build: output_deb
 
 build_container:
-	docker build -t openvino_builder $(ROOT_DIR)/docker
+	docker build -t openvino_builder:${OPENVINO_VERSION} $(ROOT_DIR)/docker
 
 build_openvino: build_container
 	docker run -it --rm --net=host \
     -v $(WORKSPACE_DIR):/workspace \
-    -v $(INSTALL_DIR):$(OPENVINO_ROOT) \
     openvino_builder \
-    ./build.bash ${VERSION}
+    /workspace/build.bash ${OPENVINO_VERSION}
 
-DEBIAN_DIR:=$(DPKG_ROOT)/DEBIAN
-CONTROL_FILE:=$(DEBIAN_DIR)/control
-build_control_file:
-	mkdir -p $(DEBIAN_DIR)
-	VERSION=$(VERSION) \
-	ARCH=$(ARCH) \
-	envsubst < $(ROOT_DIR)/template/control > $(CONTROL_FILE)
-
+output_deb: build_openvino
+	mkdir -p $(ROOT_DIR)/deb/
+	cp $(WORKSPACE_DIR)/build/*.deb $(ROOT_DIR)/deb/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ make
 ```
 
 After the build finished successfully, generated debian packages would be stored in `deb/` directory.
+
+## How it works
+
+[The official repository of OpenVINO](https://github.com/openvinotoolkit/openvino) contains some cmake files to support [CPack](https://cmake.org/cmake/help/latest/manual/cpack-generators.7.html). There is no official documentation for it but according to [this packaging.cmake file](https://github.com/openvinotoolkit/openvino/blob/master/cmake/packaging/packaging.cmake) it seems like it supports `DEB`, `RPM`, `CONDA-FORGE`, `BREW` and `NSIS`.
+
+This packaging.cmake file is included by OpenVINO's CMakeLists.tx [at this line](https://github.com/openvinotoolkit/openvino/blob/07437eec1e7644b5acf9c608a3a1f89e8f2d6d0d/CMakeLists.txt#L147), so setting `-DCPACK_GENERATOR=DEB` would configure the project to generate debian packages.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # openvino_builder
-OpenVINO builder for amd64
+
+Debian package builder for OpenVINO.
 
 ## Requirements
 
@@ -7,9 +8,10 @@ OpenVINO builder for amd64
 
 ## Build
 
-```bash
-git clone https://github.com/HarvestX/openvino_builder
-cd openvino_builder
+Just run the following command.
 
-make build
+```bash
+make
 ```
+
+After the build finished successfully, generated debian packages would be stored in `deb/` directory.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,4 @@ After the build finished successfully, generated debian packages would be stored
 
 ## How it works
 
-[The official repository of OpenVINO](https://github.com/openvinotoolkit/openvino) contains some cmake files to support [CPack](https://cmake.org/cmake/help/latest/manual/cpack-generators.7.html). There is no official documentation for it but according to [this packaging.cmake file](https://github.com/openvinotoolkit/openvino/blob/master/cmake/packaging/packaging.cmake) it seems like it supports `DEB`, `RPM`, `CONDA-FORGE`, `BREW` and `NSIS`.
-
-This packaging.cmake file is included by OpenVINO's CMakeLists.tx [at this line](https://github.com/openvinotoolkit/openvino/blob/07437eec1e7644b5acf9c608a3a1f89e8f2d6d0d/CMakeLists.txt#L147), so setting `-DCPACK_GENERATOR=DEB` would configure the project to generate debian packages.
+[The official repository of OpenVINO](https://github.com/openvinotoolkit/openvino) contains some cmake files to support [CPack](https://cmake.org/cmake/help/latest/manual/cpack-generators.7.html). There is no official documentation for it but according to [this packaging.cmake file](https://github.com/openvinotoolkit/openvino/blob/master/cmake/packaging/packaging.cmake) it seems like it supports `DEB`, `RPM`, `CONDA-FORGE`, `BREW` and `NSIS`. And it is included by OpenVINO's CMakeLists.tx [at this line](https://github.com/openvinotoolkit/openvino/blob/07437eec1e7644b5acf9c608a3a1f89e8f2d6d0d/CMakeLists.txt#L147), so setting `-DCPACK_GENERATOR=DEB` would configure the project to generate debian packages.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# Reference: https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build_linux.md
 FROM ubuntu:22.04
 
 ENV TZ=Asia/Tokyo
@@ -42,6 +43,8 @@ RUN apt-get update && \
 
 RUN apt-get install ocl-icd-libopencl1 -y
 
+# Install Intel Graphics Compute Runtime for OpenCL Driver package to enable inference on INtel integrated GPUs
+# https://github.com/intel/compute-runtime/releases/tag/19.41.14441
 RUN wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-core_1.0.13230.7_amd64.deb && \
 	wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-opencl_1.0.13230.7_amd64.deb && \
 	wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/intel-level-zero-gpu-dbgsym_1.3.25593.11_amd64.ddeb && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
 
 RUN apt-get install ocl-icd-libopencl1 -y
 
-# Install Intel Graphics Compute Runtime for OpenCL Driver package to enable inference on INtel integrated GPUs
+# Install Intel Graphics Compute Runtime for OpenCL Driver package to enable inference on Intel integrated GPUs
 # https://github.com/intel/compute-runtime/releases/tag/19.41.14441
 RUN wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-core_1.0.13230.7_amd64.deb && \
 	wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-opencl_1.0.13230.7_amd64.deb && \

--- a/template/control
+++ b/template/control
@@ -1,8 +1,0 @@
-Package: openvino
-Version: $VERSION
-Section: base
-Priority: optional
-Architecture: $ARCH
-Depends: git,cmake,libusb-1.0-0-dev,libpugixml-dev, ocl-icd-libopencl1
-Maintainer: Ar-Ray-code <ray255ar@gmail.com>
-Description: OpenVINO Cpp Runtime Package

--- a/workspace/build.bash
+++ b/workspace/build.bash
@@ -1,29 +1,22 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# exit when command fails
 set -e
 
 VERSION=$1
-
 openvino_dir="openvino-${VERSION}"
+
 if [ ! -d $openvino_dir ]; then
   git clone --recursive https://github.com/openvinotoolkit/openvino.git -b $VERSION -v $openvino_dir
 fi
 
-cd ${openvino_dir}
-
-chmod +x install_build_dependencies.sh
-./install_build_dependencies.sh
+pushd ${openvino_dir}
+/bin/bash ./install_build_dependencies.sh
 
 mkdir -p build && cd build
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DTHREADING=SEQ \
-  -DENABLE_PYTHON=OFF \
-  -DCMAKE_INSTALL_PREFIX=/opt/intel/openvino \
-  -DCMAKE_CXX_FLAGS="-march=native -mtune=native -O3" \
-  -DCMAKE_C_FLAGS="-march=native -mtune=native -O3" ..
+  -DCPACK_GENERATOR=DEB \
+  ..
+make package --jobs=$(nproc --all)
 
-make --jobs=$(nproc --all)
-
-make install
+popd


### PR DESCRIPTION
Since OpenVINO repository contains cmake files to generate debian packages by using CPack, we'll use it instead.

Generating debian packages requires several steps, and only using `dpkg-deb` is not enough. CPack Generator handles these complicated tasks by itself, so the procedure of generating debian packages becomes much simpler.